### PR TITLE
#162414254 Link Pivotal Tracker Board with Slack

### DIFF
--- a/Slack-PivotalTracker-Integration.md
+++ b/Slack-PivotalTracker-Integration.md
@@ -1,0 +1,22 @@
+# Linking Project's Pivotal Tracker Board with Slack
+
+## Description
+
+This integration of the Pivotal tracker Board with Slack will automatically update the team on the specified slack channel on activities made on the Pivotal Tracker board
+
+## Integration Steps
+
+The following steps were taken to setup the integration:
+
+1. Add the Pivotal Tracker app to the dedicated Slack channel for bots
+2. Copy the generated Webhook URL
+3. Navigate to the Project's PT Board and click the ```MORE``` tabs
+4. On the Sidebar menu, Click the Webhooks menu
+5. Add the generated Webhook URL into the input box at the Activity Web Hook
+
+
+**PS: Ensure you have Owner/Admin access on the Project's Pivotal Tracker Board**
+
+## Reference:
+
+https://sparksolutions.co/2016/01/slack-integrations-guide-github-pivotal-tracker-circle-ci-heroku-rollbar/


### PR DESCRIPTION
#### What does this PR do?
This PR links the Project's pivotal tracker board with the team's Slack channel for bots Integration

#### Description of Task to be Completed?
* Add the Pivotal Tracker app to the dedicated Slack channel for bots
* Copy the generated Webhook URL
* Navigate to the Project's PT Board and click the ```MORE``` tabs
* On the Sidebar menu, Click the Webhooks menu
* Add the generated Webhook URL into the input box at the Activity Web Hook

#### How should this be manually tested?
* N/A

#### What are the relavant pivotal tracker stories?
[Link Pivotal Tracker with Slack](https://www.pivotaltracker.com/story/show/162414254)