### PR TITLE
[#163901873] Send appropriate message to the user

### DIFF
--- a/server/helpers/MailManager.js
+++ b/server/helpers/MailManager.js
@@ -20,7 +20,9 @@ class MailManager {
    * @memberof MailManager
    */
   static sendMailNotification(message) {
-    return sgMail.send(message);
+    return process.env.NODE_ENV === 'test'
+      ? Promise.resolve()
+      : sgMail.send(message);
   }
 
   /**
@@ -38,7 +40,9 @@ class MailManager {
       subject: "Welcome to Author's Haven! Confirm your email",
       html: verifyEmailTemplate(createdUser, token)
     };
-    return sgMail.send(message);
+    return process.env.NODE_ENV === 'test'
+      ? Promise.resolve()
+      : sgMail.send(message);
   }
 }
 

--- a/server/helpers/emailTemplates/newArticleTemplate.js
+++ b/server/helpers/emailTemplates/newArticleTemplate.js
@@ -25,7 +25,7 @@ const newArticleTemplate = (follower, article, userName) => `<!DOCTYPE html>
   article.slug
 }>new article</a> .
       </p>
-      <a class="reset-btn" href=https://neon-ah-frontend-staging.herokuapp.com//articles/${
+      <a class="reset-btn" href=https://neon-ah-frontend-staging.herokuapp.com/articles/${
   article.slug
 }>
         Read Article

--- a/server/test/helpers/mailManager.spec.js
+++ b/server/test/helpers/mailManager.spec.js
@@ -11,10 +11,12 @@ describe('Mail Manager Utility Class', () => {
   describe('sendPasswordResetLink', () => {
     const sampleMailConfig = {};
     it('It should be called when provided with the right parameters', async () => {
+      process.env.NODE_ENV = 'dev';
       const stub = sinon.stub(sgMail, 'send');
       stub.resolves();
       await MailManager.sendMailNotification(sampleMailConfig);
       expect(stub.called).to.be.eql(true);
+      process.env.NODE_ENV = 'test';
     });
   });
 });


### PR DESCRIPTION
#### What does this PR do?
Fixes a bug on the signup controller.

#### Description of Task to be completed?
- Sends an appropriate message back to the user if the username or email is already in the database
- Includes tests for the feature

#### How should this be manually tested?
* Use git fetch to clone this branch.
* Switch to this branch in your machine.
* Run npm run dev to start the server.
* Sign up a user at `http://localhost:3000/api/v1/auth/signup`.
* Try to sign up the same user with the same credentials.
* The appropriate message is sent back to the user if the email or username has been taken.

#### What are the relevant pivotal tracker stories?
[Link to Pivotal Tracker](https://www.pivotaltracker.com/n/projects/2229851/stories/163901873)
